### PR TITLE
Refactor and improve type hints in MyClass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,13 @@ default_language_version:
 exclude: |
   (?x)^(
       \.git/
-    | __pycache__/
     | \.benchmarks/
     | \.pytest_cache/
+    | \.coverage
     | \.venv/
     | \.env/
+    | \*.egg-info/
+    | __pycache__/
     | venv/
     | env/
     | build/
@@ -16,7 +18,7 @@ exclude: |
     | site/
     | site-packages/
     | node_modules/
-    | .coverage
+    | logs/
   )$
 
 repos:
@@ -102,6 +104,13 @@ repos:
         files: \.sh$
 
   # --- Python ---
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        name: "🐍 black - Format python code"
+        files: \.pyi?$
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.20.0
     hooks:
@@ -110,12 +119,13 @@ repos:
         entry: "pyupgrade --py310-plus"
         files: \.pyi?$
 
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
     hooks:
-      - id: black
-        name: "🐍 black - Format python code"
+      - id: flake8
+        name: "🐍 flake8 - Lint python code"
         files: \.pyi?$
+        args: ["--max-line-length=120"]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
 try:
-    from .src.my_module01 import *
+    from .src.my_module01 import *  # noqa: F403,F401
 except ImportError:
-    from src.my_module01 import *
+    from src.my_module01 import *  # noqa: F403,F401

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-## Standard libraries
+# Standard libraries
 import sys
 import logging
 
-## Internal modules
+# Internal modules
 from my_module01 import MyClass
 
 

--- a/src/my_module01/_base.py
+++ b/src/my_module01/_base.py
@@ -72,8 +72,8 @@ class MyClass:
         """Method to clean the items based on the threshold value.
 
         Args:
-            items     (list[float], None, optional): List of float items to be processed. Defaults to None.
-            threshold (float, None      , optional): Threshold value for the cleaning process. Defaults to None.
+            items     (list[float] | None, optional): List of float items to be processed. Defaults to None.
+            threshold (float | None      , optional): Threshold value for the cleaning process. Defaults to None.
 
         Raises:
             RuntimeError: If `items` attribute is not set.
@@ -112,8 +112,8 @@ class MyClass:
         """Wrapper method for the __call__ method.
 
         Args:
-            items     (list[float], None, optional): List of float items to be processed. Defaults to None.
-            threshold (float, None      , optional): Threshold value for the cleaning process. Defaults to None.
+            items     (list[float] | None, optional): List of float items to be processed. Defaults to None.
+            threshold (float | None      , optional): Threshold value for the cleaning process. Defaults to None.
 
         Returns:
             list[float]: List of cleaned items.

--- a/src/my_module01/_base.py
+++ b/src/my_module01/_base.py
@@ -39,7 +39,7 @@ class MyClass:
         """Initializer method for the MyClass class.
 
         Args:
-            items  (list[float], None]                     , optional): List of float items to be processed.
+            items  (list[float] | None                     , optional): List of float items to be processed.
                                                                             Defaults to None.
             config (MyClassConfigPM | dict[str, Any] | None, optional): Configuration for the module. Defaults to None.
         """

--- a/src/my_module01/_base.py
+++ b/src/my_module01/_base.py
@@ -1,12 +1,12 @@
-## Standard libraries
+# Standard libraries
 import pprint
 import logging
 from typing import Any
 
-## Third-party libraries
+# Third-party libraries
 from pydantic import validate_call
 
-## Internal modules
+# Internal modules
 from .__version__ import __version__
 from . import _utils as utils
 from .config import MyClassConfigPM
@@ -39,8 +39,9 @@ class MyClass:
         """Initializer method for the MyClass class.
 
         Args:
-            items  (Union[List[float], None]                    , optional): List of float items to be processed. Defaults to None.
-            config (Union[MyClassConfigPM, Dict[str, Any], None], optional): Configuration for the module. Defaults to None.
+            items  (list[float], None]                     , optional): List of float items to be processed.
+                                                                            Defaults to None.
+            config (MyClassConfigPM | dict[str, Any] | None, optional): Configuration for the module. Defaults to None.
         """
 
         logger.debug(
@@ -120,8 +121,8 @@ class MyClass:
 
         return self.__call__(items=items, threshold=threshold)
 
-    ### ATTRIBUTES ###
-    ## config ##
+    # ATTRIBUTES
+    # config
     @property
     def config(self) -> MyClassConfigPM:
         try:
@@ -145,9 +146,9 @@ class MyClass:
 
         self.__config = config
 
-    ## config ##
+    # config
 
-    ## items ##
+    # items
     @property
     def items(self) -> list[float]:
         try:
@@ -166,7 +167,8 @@ class MyClass:
             self.config.max_length < len(items)
         ):
             raise ValueError(
-                f"`items` attribute length '{len(items)}' is too short or too long, must be between '{self.config.min_length}' and '{self.config.max_length}'!"
+                f"`items` attribute length '{len(items)}' is too short or too long, "
+                f"must be between '{self.config.min_length}' and '{self.config.max_length}'!"
             )
 
         for _item in items:
@@ -177,15 +179,16 @@ class MyClass:
 
             if (_item < self.config.min_value) or (self.config.max_value < _item):
                 raise ValueError(
-                    f"`items` attribute item value '{_item}' is not in the allowed range, must be between '{self.config.min_value}' and '{self.config.max_value}'!"
+                    f"`items` attribute item value '{_item}' is not in the allowed range, "
+                    f"must be between '{self.config.min_value}' and '{self.config.max_value}'!"
                 )
 
         self.__items = items
 
-    ## items ##
-    ### ATTRIBUTES ###
+    # items
+    # ATTRIBUTES
 
-    ## METHOD OVERRIDING ##
+    # METHOD OVERRIDING
     def __str__(self):
         _self_dict = utils.clean_obj_dict(self.__dict__, self.__class__.__name__)
         _self_str = f"{self.__class__.__name__}: {pprint.pformat(_self_dict)}"
@@ -195,7 +198,7 @@ class MyClass:
         _self_repr = utils.obj_to_repr(self)
         return _self_repr
 
-    ## METHOD OVERRIDING ##
+    # METHOD OVERRIDING
 
 
 __all__ = ["MyClass"]

--- a/src/my_module01/_base.py
+++ b/src/my_module01/_base.py
@@ -72,14 +72,14 @@ class MyClass:
         """Method to clean the items based on the threshold value.
 
         Args:
-            items     (Union[List[float], None], optional): List of float items to be processed. Defaults to None.
-            threshold (Union[float, None]      , optional): Threshold value for the cleaning process. Defaults to None.
+            items     (list[float], None, optional): List of float items to be processed. Defaults to None.
+            threshold (float, None      , optional): Threshold value for the cleaning process. Defaults to None.
 
         Raises:
             RuntimeError: If `items` attribute is not set.
 
         Returns:
-            List[float]: List of cleaned items.
+            list[float]: List of cleaned items.
         """
 
         if items:
@@ -112,11 +112,11 @@ class MyClass:
         """Wrapper method for the __call__ method.
 
         Args:
-            items     (Union[List[float], None], optional): List of float items to be processed. Defaults to None.
-            threshold (Union[float, None]      , optional): Threshold value for the cleaning process. Defaults to None.
+            items     (list[float], None, optional): List of float items to be processed. Defaults to None.
+            threshold (float, None      , optional): Threshold value for the cleaning process. Defaults to None.
 
         Returns:
-            List[float]: List of cleaned items.
+            list[float]: List of cleaned items.
         """
 
         return self.__call__(items=items, threshold=threshold)


### PR DESCRIPTION
This pull request mainly improves code style consistency, updates type annotations for modern Python, and enhances the pre-commit configuration for better code quality enforcement. The most significant changes are grouped below.

**Pre-commit configuration improvements:**

* Added `black` and `flake8` hooks to `.pre-commit-config.yaml` for automatic formatting and linting of Python code, including configuration for max line length. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R107-R113) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L113-R128)
* Refined the exclusion list in `.pre-commit-config.yaml` to more accurately ignore build, cache, and environment files and directories.

**Code style and annotation updates:**

* Updated type annotations in `src/my_module01/_base.py` to use modern Python syntax (e.g., `list[float] | None` instead of `Union[List[float], None]`), and improved docstrings to match. [[1]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL42-R44) [[2]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL74-R82) [[3]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL114-R125)
* Standardized comments and section headers in `src/my_module01/_base.py` for clarity and consistency. [[1]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL1-R9) [[2]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL114-R125) [[3]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL148-R151) [[4]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL180-R191) [[5]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL198-R201)

**Minor fixes and improvements:**

* Improved error messages for value and length checks in the `items` property setter for better readability. [[1]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL169-R171) [[2]](diffhunk://#diff-361a13913d7281011c1fc9e4094b5814f5f83d84b96e1bb732caf1af88c35ccbL180-R191)
* Added `# noqa: F403,F401` comments to import statements in `__init__.py` to suppress linting warnings.
* Cleaned up comments in `examples/simple/main.py` for consistency.